### PR TITLE
Add a link to timgws/QueryBuilderParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Setting](https://github.com/Phil-F/Setting) - Persistent configuration settings that are stored in JSON files
 * [Teamwork](https://github.com/mpociot/teamwork) - User to team associations with an invite system
 * [Validating](https://github.com/dwightwatson/validating) - Trait for validating Eloquent models
+* [QueryBuilderParser](https://github.com/timgws/QueryBuilderParser) - Server side integration for the jQuery QueryBuilder
 
 ##### Working with Javascript
 * [Laroute](https://github.com/aaronlord/laroute) - Generate Laravel route URLs from JavaScript


### PR DESCRIPTION
**QueryBuilderParser** is designed mainly to be used inside Laravel projects, however it can be used outside Laravel projects by using Illuminate/Database.

A simple to use query builder for the [jQuery QueryBuilder plugin](http://mistic100.github.io/jQuery-QueryBuilder/).