### PR TITLE
The link to Laravel API docs appears to have changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 ## Essentials
 * [Laravel](http://laravel.com)
 * [Laravel Documentation](http://laravel.com/docs)
-* [Laravel API Reference](http://laravel.com/api)
+* [Laravel API Reference](http://laravel.com/api/master)
 * [Lumen](http://lumen.laravel.com)
 * [Lumen Documentation](http://lumen.laravel.com/docs)
 * [Laracasts](http://laracasts.com)


### PR DESCRIPTION
It seems to want a specific version, but `master` is probably a suitable default