### PR TITLE
Adding Elasticsearch ORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 ##### Search
 
 * [Algolia Search](https://github.com/algolia/algoliasearch-laravel) - Integrates the Algolia Search API to the Laravel Eloquent ORM
+* [Elasticsearch ORM](https://github.com/basemkhirat/elasticsearch) - Laravel, Lumen and Native php elasticseach query builder to build complex queries using an elegant syntax
 * [Elasticquent](https://github.com/elasticquent/Elasticquent) - Elasticsearch for Eloquent models
 * [Plastic](https://github.com/sleimanx2/plastic) - Fluently mapping and searching Elasticsearch
 * [Laravel Search](https://github.com/mmanos/laravel-search) - Unified API for Elasticsearch, Algolia, and ZendSearch


### PR DESCRIPTION
Elasticsearch data model for types and indices inspired from laravel eloquent.
Feeling free to create, drop, mapping and reindexing throw easy artisan console commands.
Lumen framework support.
Native php and composer based applications support.
Can be used as a laravel scout driver.
Dealing with multiple elasticsearch connections at the same time.
Awesome pagination based on LengthAwarePagination.
Caching queries using a caching layer over query builder built on laravel cache.