### PR TITLE
Add Laravel Email Domain Blacklist package

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Laravel Collection Macros](https://github.com/spatie/laravel-collection-macros) - A set of handy collection macros
 * [Laravel Cookie Consent](https://github.com/spatie/laravel-cookie-consent) - Make your Laravel app comply with the crazy EU cookie law
 * [Laravel Datatables](https://github.com/yajra/laravel-datatables) - jQuery DataTables API
+* [Laravel Email Domain Blacklist](https://github.com/alariva/laravel-email-domain-blacklist) - Email domain blacklist validation rule extension
 * [Laravel GeoIP](https://github.com/Torann/laravel-geoip) - Determine the location of website visitors based on their IP addresses
 * [Laravel Hashids](https://github.com/vinkla/laravel-hashids) - Generate unique, non-sequential ids using [Hashids](http://hashids.org/php/)
 * [Laravel Impersonate](https://github.com/404labfr/laravel-impersonate) - A package to authenticate as one of your users


### PR DESCRIPTION
Laravel Email Domain Blacklist is a package to validate email input that it's not blacklisted for a specific domain name.
The blacklist may be third party remote sourced or local.
Provides background console updater and on-request auto-update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chiraggude/awesome-laravel/437)
<!-- Reviewable:end -->
