### PR TITLE
Laravel Excel provides only export function

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Laravel Snappy](https://github.com/barryvdh/laravel-snappy) - HTML to PDF generator using wkhtmltopdf
 * [Laravel DOMPDF](https://github.com/barryvdh/laravel-dompdf) - HTML to PDF generator using [dompdf](https://github.com/dompdf/dompdf)
 * [Laravel Stapler](https://github.com/CodeSleeve/laravel-stapler) - ORM-based file upload manager
-* [Laravel Excel](https://github.com/Maatwebsite/Laravel-Excel) - Import and export Excel and CSV files
+* [Laravel Excel](https://github.com/Maatwebsite/Laravel-Excel) - Export Excel and CSV files
 
 ##### Integration with Javascript
 


### PR DESCRIPTION
The [official website](https://laravel-excel.maatwebsite.nl/) and the [github repo](https://github.com/Maatwebsite/Laravel-Excel) healines says:

> Supercharged Excel **exports** in Laravel

The web site has also its three level-2 titles about exports:

> **Export** collections to Excel. / Supercharged **exports**. / **Export** blade views.

It seems this package is about export only. Still, import are announced for version 3.1.

