### PR TITLE
Laravel graphql is no longuer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Dingo API](https://github.com/dingo/api) - Multi-purpose toolkit for developing RESTful APIs
 * [Laravel CORS](https://github.com/barryvdh/laravel-cors) - Add CORS (Cross-Origin Resource Sharing) headers support
 * [Laravel Fractal](https://github.com/spatie/laravel-fractal) - Output complex, flexible, AJAX/RESTful data structures with Fractal
-* [Laravel GraphQL](https://github.com/Folkloreatelier/laravel-graphql) - Supports Relay, eloquent models, validation and GraphiQL
+* [Laravel GraphQL](https://github.com/rebing/graphql-laravel) - Supports Relay, eloquent models, validation and GraphiQL
 * [Lighthouse](https://github.com/nuwave/lighthouse) - An up and coming GraphQL library for Laravel
 * [Laravel Responder](https://github.com/flugger/laravel-responder) - Build custom API responses with Fractal
 


### PR DESCRIPTION
[https://github.com/folkloreinc/laravel-graphql#this-package-is-no-longuer-maintained-please-use-rebinggraphql-laravel-or-other-laravel-graphql-packages](https://github.com/folkloreinc/laravel-graphql#this-package-is-no-longuer-maintained-please-use-rebinggraphql-laravel-or-other-laravel-graphql-packages)

As folkloreinc/laravel-graphql readme says "This package is no longuer maintained", and this repository has been archived. But rebing/graphql-laravel can instead it almost perfect.