### PR TITLE
Add iDoc (Interactive api documentation generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Laravel API/Scaffold/CRUD Generator](https://github.com/InfyOmLabs/laravel-generator) - Generator for APIs, CRUD scaffolds etc.
 * [Laravel Tinx](https://github.com/furey/tinx) - Reload your Laravel Tinker session from inside Tinker
 * [Laravel API Documentation Generator](https://github.com/mpociot/laravel-apidoc-generator) - Automatically generate your API documentation
+* [Laravel iDoc Generator](https://github.com/ovac/idoc) - Automatically generate interractive API documentation
 * [Laravel Packager](https://github.com/Jeroen-G/Laravel-Packager) - A CLI tool for creating Laravel packages
 * [Workbench Export to Migrations](https://github.com/beckenrode/mysql-workbench-export-laravel-5-migrations) - Workbench plugin for exporting Models to Laravel migrations
 * [Laravel Decomposer](https://github.com/lubusIN/laravel-decomposer) - List all installed packages, their dependencies, app & server details


### PR DESCRIPTION
Automatically generate interactive API documentation from your existing Laravel routes. Take a look at the [official documentation](https://www.ovac4u.com/idoc) or the [example](https://www.ovac4u.com/idoc/live). Inspired by [Laravel API Documentation Generator](mpociot/laravel-apidoc-generator)