### PR TITLE
Remove Rocketeer

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,6 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 
 * [Deployer](https://deployer.org/) - A deployment tool with support for Laravel out of the box
 * [Envoyer](https://envoyer.io/) - Zero down-time Deployer for PHP & Laravel projects
-* [Rocketeer](https://github.com/rocketeers/rocketeer) - Task runner and deployment package
 
 ## Code Snippets
 


### PR DESCRIPTION
Rocketeer isn't maintained anymore, they even suggest you to use Deployer on the github repo!