### PR TITLE
Add Laravel Upgrade Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Laravel Nova](https://nova.laravel.com/) - Nova is a beautifully designed administration panel for Laravel
 * [Laravel Love](https://github.com/cybercog/laravel-love) - It lets people express how they feel about the content. React on Eloquent models with Likes or Dislikes.
 * [stancl/tenancy](https://github.com/stancl/tenancy) - Automatic tenancy for your Laravel app. No code changes needed.
+* [Laravel Upgrade Helper](https://github.com/laravel-upgrade-helper/laravel-upgrade-helper.github.io) - Quickly view differences between versions for Laravel.
 
 ##### Media & Document Management
 


### PR DESCRIPTION
Quickly view differences between versions for Laravel. Support Laravel 5.5 (LTS) and above. Download patch file as your projects requirements.