### PR TITLE
Add Starter Project: Laravel + Vue 3 Boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Laravel Vue Boilerplate](https://github.com/alefesouza/laravel-vue-boilerplate)
 * [Laravel Enso](https://github.com/laravel-enso/enso)
 * [Laravel Template with Vue](https://github.com/wmhello/laravel_template_with_vue)
+* [Laravel Breeze with Vue3 - Boilerplate / Starter kit](https://github.com/fsgreco/vue3-laravel-api)
 
 ## Codebases for Reference
 


### PR DESCRIPTION
Added an implementation of the **Laravel Breeze** application / authentication starter kit frontend in Vue.js v3. How a library can become a framework with the help of **pinia** and **vue-router**. This repository emulates the same purpose achieved by Taylor Otwell with his demo repository "breeze-next", but with VueJs v3 instead of React.