### PR TITLE
Add Laravel AI Email Assistant to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Laravel Heyman](https://github.com/imanghafoori1/laravel-heyman) - Heyman continues where the above role-permission packages left off
 
 ##### Utilities
-
+*[Laravel AI Email Assistant](https://github.com/intel1590/laravel-ai-email-assistant) - AI-powered Laravel package to generate personalized, well-structured emails (welcome, follow-up, sales pitch, and more) using OpenAI or Mock Mode. Developed by [Om Diaries](https://github.com/intel1590).
 * [Awes.io](https://github.com/awes-io/awes-io) - boilerplate for CRM, SaaS, ERP based on Vue (Nuxt.js), TailwindCSS plus Laravel as a backend.
 * [Artisan View](https://github.com/svenluijten/artisan-view) - Manage the views in Laravel projects via artisan
 * [Bootstrapper](https://github.com/patricktalmadge/bootstrapper/) - Set of classes to create Bootstrap 3 markup


### PR DESCRIPTION
Added Laravel AI Email Assistant under the Utilities section.

Laravel AI Email Assistant is an AI-powered email generation tool for Laravel 
applications. It helps developers quickly craft personalized, professional 
emails such as welcome messages, follow-ups, and marketing content using 
OpenAI or Mock Mode. 

🔗 GitHub: https://github.com/intel1590/laravel-ai-email-assistant  
📦 Packagist: https://packagist.org/packages/omdiaries/laravel-ai-email-assistant  
📘 PHPClasses: https://www.phpclasses.org/package/13631  
🌐 Docs: https://intel1590.github.io/laravel-ai-email-assistant/
