### PR TITLE
Add Laravel Multi-Tenant SaaS Starter to Starter Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Inspired by [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 * [Laravel Vue Boilerplate](https://github.com/alefesouza/laravel-vue-boilerplate)
 * [Laravel Enso](https://github.com/laravel-enso/enso)
 * [Laravel Template with Vue](https://github.com/wmhello/laravel_template_with_vue)
+* [Laravel Multi-Tenant SaaS Starter](https://github.com/alihamzahq/laravel-multi-tenant-saas-starter)
 
 ## Codebases for Reference
 


### PR DESCRIPTION
Adding **Laravel Multi-Tenant SaaS Starter** to the Starter Projects section.

It's an open-source multi-tenant SaaS starter kit for Laravel 12 + React 19 + Inertia.js, using Stancl/Tenancy for database-per-tenant isolation. Includes a central admin panel with tenant impersonation via signed URLs, RBAC inside tenants, REST API with Laravel Sanctum, and subdomain-based routing. MIT licensed, demo credentials in the README, runs locally with subdomain config.

**Repo:** https://github.com/alihamzahq/laravel-multi-tenant-saas-starter

Format matches the existing title-only convention of the Starter Projects section (one bullet, title + link only). Description is here in the PR for context.

Thanks for maintaining this list!